### PR TITLE
Update 2021 SIGDAT Officers, Events, Board

### DIFF
--- a/_pages/events.md
+++ b/_pages/events.md
@@ -11,6 +11,12 @@ toc_icon: "cog"
 
 *Note*: The links for the older conferences and workshops no longer exist on the web. For those links, a snapshot from the Internet Archive is used instead.
 
+### 2020 Conference on Empirical Methods in Natural Language Processing and 9th International Joint Conference on Natural Language Processing (EMNLP 2020)
+- November 16-November 20, 2020
+- Online
+- [Website](https://2020.emnlp.org/)
+- [Proceedings](https://www.aclweb.org/anthology/events/emnlp-2020/)
+
 ### 2019 Conference on Empirical Methods in Natural Language Processing and 9th International Joint Conference on Natural Language Processing (EMNLP-IJCNLP 2019)
 - November 3-November 7, 2019
 - Hong Kong, China

--- a/_pages/officers.md
+++ b/_pages/officers.md
@@ -10,6 +10,11 @@ toc_icon: "cog"
 ---
 
 (**Position**, Name, Affiliation, Country/territory)
+## 2020
+- **President**: Ani Nenkova, University of Pennsylvania, USA<br/>
+- **Vice President**: Iryna Gurevych, Technische Universität Darmstadt, Germany<br/>
+- **Vice President-Elect**: Hang Li, ByteDance, China<br/>
+- **Secretary-Treasurer**: Chin-Yew Lin, Microsoft Research Asia, China
 
 ## 2019
 - **President**: Jian Su, Institute for Infocomm Research, Singapore<br/>

--- a/_pages/organization.md
+++ b/_pages/organization.md
@@ -13,9 +13,9 @@ SIGDAT is run by consensus vote of its organizing committee, consisting of the o
 
 ## Officers in 2020:  
 
-- **President**: Ani Nenkova, University of Pennsylvania, USA<br/>
-- **Vice President**: Iryna Gurevych, Technische Universität Darmstadt, Germany<br/>
-- **Vice President-Elect**: Hang Li, ByteDance, China<br/>
+- **President**: Iryna Gurevych, Technische Universität Darmstadt, Germany<br/>
+- **Vice President**: Hang Li, ByteDance, China<br/>
+- **Vice President-Elect**: Mona Diab, George Washington University, USA<br/>
 - **Secretary-Treasurer**: Chin-Yew Lin, Microsoft Research Asia, China
 
 [Previous Officers](/officers)
@@ -25,12 +25,13 @@ SIGDAT is run by consensus vote of its organizing committee, consisting of the o
 - The current ACL treasurer, ex-officio<br/>
 - Priscilla Rasmussen<br/>
 - Graeme Hirst, University of Toronto, Canada<br/>
--  David Yarowsky, Johns Hopkins University, USA (North American Representative)<br/>
+- David Yarowsky, Johns Hopkins University, USA (North American Representative)<br/>
 - Sebastian Riedel, University College London, UK (European Representative)<br/>
 - Pascale Fung, Hong Kong University of Science &amp; Technology, China (Asian Representative)<br/>
 - Yuji Matsumoto, Nara Institute of Science and Technology, Japan (Asian Representative) 
 
 ## Advisory Board Members
+- Ani Nenkova, Adobe, USA<br/> 
 - Regina Barzilay, MIT, USA<br/>
 - Chris Callison-Burch, University of Pennsylvania, USA<br/>
 - Claire Cardie, Cornell University, USA<br/>
@@ -60,7 +61,6 @@ SIGDAT is run by consensus vote of its organizing committee, consisting of the o
 - Dan Jurafsky, Stanford University, USA<br/>
 - Philipp Koehn, Johns Hopkins University, USA<br/>
 - Mark Johnson, Macquarie University, Australia<br/>
-- Lillian Lee, Cornell University, USA<br/>
 - Hang Li, Toutiao, China<br/>
 - Dekang Lin, Google, USA<br/>
 - Lluís Màrquez, Qatar Computing Research Institute, Qatar<br/>


### PR DESCRIPTION
Update 2021 SIGDAT Offices
Add EMNLP 2020 to events
Remove Lilian Lee from SIGDAT board list